### PR TITLE
Updated CMake Required to 3.22.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.22)
 project(cmakeme LANGUAGES NONE VERSION 0.2.0)
 
 # Since cmakeme is not installed, we load the individual modules manually

--- a/cmakeme_python.cmake
+++ b/cmakeme_python.cmake
@@ -30,31 +30,29 @@ Commands
         ``pkgname``
         The name of the python package
 #]=======================================================================]
-# TODO: this is deprecated so fix when we bump minimum cmake version
-find_package(PythonInterp)
 
 function(cmakeme_python directory pkgname)
-  if(PYTHONINTERP_FOUND)
-    # Build the wheel during code generation time
-    set(outdir "${CMAKE_BINARY_DIR}/dist")
-
-    # This target actually builds the wheel
-    add_custom_target(${pkgname}-python ALL
-      COMMAND ${CMAKE_COMMAND} -E make_directory ${outdir}
-      COMMAND ${PYTHON_EXECUTABLE} -m build ${directory} --outdir ${outdir}
-      )
-
-    # This target gets the wheel filename (which is difficult to compute beforehand)
-    add_custom_target(${pkgname}-python-wheel ALL
-      COMMAND ${CMAKE_COMMAND} -E echo ${outdir}/${pkgname}-*.whl > ${outdir}/${pkgname}-wheel-name
-      DEPENDS ${pkgname}-python
-      )
-
-    # Install the wheel. This requires us to read the wheel name and then use it to install. We must remove the old wheel first
-    # Note: Use OUTPUT_VARIABLE to capture output of execute_process. Results can be output using message(), which is useful for debugging
-    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E cat ${outdir}/${pkgname}-wheel-name OUTPUT_VARIABLE wheel_name)
-                execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install --force-reinstall --prefix ${CMAKE_INSTALL_PREFIX} \${wheel_name})")
-  else()
-    message(WARNING "Cannot cmakeme_python because Python Interpreter not found")
+  if(NOT Python3_Interpreter_FOUND)
+    find_package(Python3 REQUIRED COMPONENTS Interpreter )
   endif()
+
+  # Build the wheel during code generation time
+  set(outdir "${CMAKE_BINARY_DIR}/dist")
+
+  # This target actually builds the wheel
+  add_custom_target(${pkgname}-python ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${outdir}
+    COMMAND ${PYTHON_EXECUTABLE} -m build ${directory} --outdir ${outdir}
+    )
+
+  # This target gets the wheel filename (which is difficult to compute beforehand)
+  add_custom_target(${pkgname}-python-wheel ALL
+    COMMAND ${CMAKE_COMMAND} -E echo ${outdir}/${pkgname}-*.whl > ${outdir}/${pkgname}-wheel-name
+    DEPENDS ${pkgname}-python
+    )
+
+  # Install the wheel. This requires us to read the wheel name and then use it to install. We must remove the old wheel first
+  # Note: Use OUTPUT_VARIABLE to capture output of execute_process. Results can be output using message(), which is useful for debugging
+  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E cat ${outdir}/${pkgname}-wheel-name OUTPUT_VARIABLE wheel_name)
+                execute_process(COMMAND ${Python3_EXECUTABLE} -m pip install --force-reinstall --prefix ${CMAKE_INSTALL_PREFIX} \${wheel_name})")
 endfunction()


### PR DESCRIPTION
fixes issue #2 
Cmake 3.22 is the version used on Ubuntu 22.04.
(But it's easy to install newer versions of cmake).

CMake 3.22 brings several features that make developign this package easier
and better.

For example, the new method of finding python: FindPython3, easily ensures
that python3 rather than python2 is found