### PR TITLE
1/2 fix for omnid_lib not building without wifi

### DIFF
--- a/cmakeme_python.cmake
+++ b/cmakeme_python.cmake
@@ -54,7 +54,7 @@ function(cmakeme_python directory pkgname)
   # (we use WORKING_DIRECTORY because cmake -E tar has no way to specify an output directory)
   add_custom_target(${pkgname}-python ALL
     COMMAND ${CMAKE_COMMAND} -E make_directory ${outdir}
-    COMMAND ${Python3_EXECUTABLE} -m build --wheel --outdir ${outdir} ${directory}
+    COMMAND ${Python3_EXECUTABLE} -m build --wheel --no-isolation --outdir ${outdir} ${directory}
     COMMAND ${CMAKE_COMMAND} -E tar x ${outdir}/${pkgname}-*.whl --format=zip
     WORKING_DIRECTORY ${wheeldir}
     DEPENDS ${pkgname}-make-wheel-dir


### PR DESCRIPTION
Added --no-isolation flag to ensure cmake would not create a new venv and try to install setup_tools into the new venv. --no-isolation forces the system to use the local version of setuptools. This ensured the omnid_lib package can build without wifi. 


