### PR TITLE
colcon test error fixed

### DIFF
--- a/tests/githash_test/AdditionalTests.cmake
+++ b/tests/githash_test/AdditionalTests.cmake
@@ -39,8 +39,8 @@ endif()
 # Manually hash the files that should go into githash exe
 execute_process(COMMAND ${CMAKE_COMMAND} -E cat
   "${TEST_DIR}/include/githash_lib.h"
-  "${TEST_BIN_DIR}/cmakeme/include/githash_test/githash_test_git_hash.h"
   "${TEST_BIN_DIR}/cmakeme/include/githash_test/githash_test_lib_hash.h"
+  "${TEST_BIN_DIR}/cmakeme/include/githash_test/githash_test_git_hash.h"
   "${TEST_BIN_DIR}/libgithash_test_lib.a"
   "${TEST_DIR}/githash_test_exe.c"
   "${TEST_DIR}/CMakeLists.txt"


### PR DESCRIPTION
git_hash_target.bin listed files in this order for the executable:

I determined this by printing out the files that were concatenated together. 

  "${TEST_DIR}/include/githash_lib.h"
  "${TEST_BIN_DIR}/cmakeme/include/githash_test/githash_test_lib_hash.h"
  "${TEST_BIN_DIR}/cmakeme/include/githash_test/githash_test_git_hash.h"
  "${TEST_BIN_DIR}/libgithash_test_lib.a"
  "${TEST_DIR}/githash_test_exe.c"
  "${TEST_DIR}/CMakeLists.txt"
  
The test in AdditionalTests.cmake checked files in a specific hard coded manner that didn't match what git_hash_target.bin expected. I modified the order of the files that were concatenated to match what git_has_target.bin returned. This fixed the colcon test error. 